### PR TITLE
Add travis config for pull requests and builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
 language: node_js
 node_js:
   - "node"
-script: yarn lint && yarn test
+jobs:
+  include:
+    - script: yarn test
+    - script: yarn lint
+    - stage: build
+      script: yarn build
+    - stage: deploy
+      script: echo todo
+stages:
+  - test
+  - name: build
+    if: branch = master AND type = push
+  - name: deploy
+    if: branch = master AND type = push


### PR DESCRIPTION
Add configuration for TravisCI builds. Run tests and the linter for pull requests/branches, but run the build only for the master branch.