### PR TITLE
Preserve turn when in combat

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -13,7 +13,8 @@ it('renders without crashing', () => {
         addInitiative={() => {}}
         removeInitiative={() => {}}
         nextTurn={() => {}}
-        toggleInCombat={() => {}} />
+        toggleInCombat={() => {}}
+        inCombat={false} />
     </Provider>,
     div)
   ReactDOM.unmountComponentAtNode(div)

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -29,10 +29,12 @@ const compareInitiativeDescending = function (a, b) {
   return b.initiative - a.initiative
 }
 
-// expects sorted array
-const determineTurnOrder = state => {
-  state[0].turn = true
-  return state
+const resetTurnOrder = initiativeList => {
+  initiativeList.forEach(character => {
+    character.turn = false
+  })
+  initiativeList[0].turn = true
+  return initiativeList
 }
 
 const gotoNextTurn = initiativeList => {
@@ -56,15 +58,22 @@ export function initiative (state = {
 }, action = {}) {
   switch (action.type) {
     case ADD_INITIATIVE:
-      const newInitiativeList = state.initiativeList.concat(action.character)
-        .sort(compareInitiativeDescending)
-        .map(character => ({
-          ...character,
-          turn: false
-        }))
+      if (state.initiativeList.length === 0) {
+        return {
+          ...state,
+          initiativeList: [{
+            ...action.character,
+            turn: true
+          }]
+        }
+      }
+      const newInitiativeList = state.initiativeList.concat({
+        ...action.character,
+        turn: false
+      }).sort(compareInitiativeDescending)
       return {
         ...state,
-        initiativeList: determineTurnOrder(newInitiativeList)
+        initiativeList: state.inCombat ? newInitiativeList : resetTurnOrder(newInitiativeList)
       }
     case REMOVE_INITIATIVE:
       if (state.initiativeList.length === 0) {

--- a/src/reducers.test.js
+++ b/src/reducers.test.js
@@ -24,106 +24,226 @@ describe('reducer', () => {
   })
 })
 
-describe('addInitiative', () => {
-  it('should add initiative for the first character', () => {
-    const character = {
+describe('when out of combat', () => {
+  describe('addInitiative', () => {
+    it('should add initiative for the first character', () => {
+      const character = {
+        name: 'Karis',
+        initiative: 16
+      }
+      expect(initiative(undefined, addInitiative(character))).toEqual({
+        inCombat: false,
+        initiativeList: [{
+          ...character,
+          turn: true
+        }]
+      })
+    })
+    it('should add a character with higher initiative', () => {
+      const newCharacter = {
+        name: 'newPerson',
+        initiative: 18
+      }
+      expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
+        inCombat: false,
+        initiativeList: [{
+          name: 'newPerson',
+          initiative: 18,
+          turn: true
+        }, {
+          name: 'Karis',
+          initiative: 16,
+          turn: false
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }]
+      })
+    })
+    it('should add a character with low initiative', () => {
+      const newCharacter = {
+        name: 'newPerson',
+        initiative: 12
+      }
+      expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
+        inCombat: false,
+        initiativeList: [{
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }, {
+          name: 'newPerson',
+          initiative: 12,
+          turn: false
+        }]
+      })
+    })
+    it('should add a character with the same initiative as another character', () => {
+      const newCharacter = {
+        name: 'newPerson',
+        initiative: 16
+      }
+      expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
+        inCombat: false,
+        initiativeList: [{
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'newPerson',
+          initiative: 16,
+          turn: false
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }]
+      })
+    })
+    it('should add a character with initiative somewhere in the middle', () => {
+      const newCharacter = {
+        name: 'newPerson',
+        initiative: 15
+      }
+      expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
+        inCombat: false,
+        initiativeList: [{
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'newPerson',
+          initiative: 15,
+          turn: false
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }]
+      })
+    })
+  })
+})
+
+describe('when in combat', () => {
+  const inCombatInitialState = {
+    inCombat: true,
+    initiativeList: [{
       name: 'Karis',
-      initiative: 16
-    }
-    expect(initiative(undefined, addInitiative(character))).toEqual({
-      inCombat: false,
-      initiativeList: [{
-        ...character,
-        turn: true
-      }]
-    })
-  })
-  it('should add a character with higher initiative', () => {
-    const newCharacter = {
-      name: 'newPerson',
-      initiative: 18
-    }
-    expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
-      inCombat: false,
-      initiativeList: [{
-        name: 'newPerson',
-        initiative: 18,
-        turn: true
-      }, {
+      initiative: 16,
+      turn: true
+    }, {
+      name: 'Riku',
+      initiative: 14,
+      turn: false
+    }]
+  }
+  describe('addInitiative', () => {
+    it('should add initiative for the first character', () => {
+      const character = {
         name: 'Karis',
-        initiative: 16,
-        turn: false
-      }, {
-        name: 'Riku',
-        initiative: 14,
-        turn: false
-      }]
+        initiative: 16
+      }
+      expect(initiative({inCombat: true, initiativeList: []}, addInitiative(character))).toEqual({
+        inCombat: true,
+        initiativeList: [{
+          ...character,
+          turn: true
+        }]
+      })
     })
-  })
-  it('should add a character with low initiative', () => {
-    const newCharacter = {
-      name: 'newPerson',
-      initiative: 12
-    }
-    expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
-      inCombat: false,
-      initiativeList: [{
-        name: 'Karis',
-        initiative: 16,
-        turn: true
-      }, {
-        name: 'Riku',
-        initiative: 14,
-        turn: false
-      }, {
+    it('should add a character with higher initiative', () => {
+      const newCharacter = {
         name: 'newPerson',
-        initiative: 12,
-        turn: false
-      }]
+        initiative: 18
+      }
+      expect(initiative(inCombatInitialState, addInitiative(newCharacter))).toEqual({
+        inCombat: true,
+        initiativeList: [{
+          name: 'newPerson',
+          initiative: 18,
+          turn: false
+        }, {
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }]
+      })
     })
-  })
-  it('should add a character with the same initiative as another character', () => {
-    const newCharacter = {
-      name: 'newPerson',
-      initiative: 16
-    }
-    expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
-      inCombat: false,
-      initiativeList: [{
-        name: 'Karis',
-        initiative: 16,
-        turn: true
-      }, {
+    it('should add a character with low initiative', () => {
+      const newCharacter = {
         name: 'newPerson',
-        initiative: 16,
-        turn: false
-      }, {
-        name: 'Riku',
-        initiative: 14,
-        turn: false
-      }]
+        initiative: 12
+      }
+      expect(initiative(inCombatInitialState, addInitiative(newCharacter))).toEqual({
+        inCombat: true,
+        initiativeList: [{
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }, {
+          name: 'newPerson',
+          initiative: 12,
+          turn: false
+        }]
+      })
     })
-  })
-  it('should add a character with initiative somewhere in the middle', () => {
-    const newCharacter = {
-      name: 'newPerson',
-      initiative: 15
-    }
-    expect(initiative(initialState, addInitiative(newCharacter))).toEqual({
-      inCombat: false,
-      initiativeList: [{
-        name: 'Karis',
-        initiative: 16,
-        turn: true
-      }, {
+    it('should add a character with the same initiative as another character', () => {
+      const newCharacter = {
         name: 'newPerson',
-        initiative: 15,
-        turn: false
-      }, {
-        name: 'Riku',
-        initiative: 14,
-        turn: false
-      }]
+        initiative: 16
+      }
+      expect(initiative(inCombatInitialState, addInitiative(newCharacter))).toEqual({
+        inCombat: true,
+        initiativeList: [{
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'newPerson',
+          initiative: 16,
+          turn: false
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }]
+      })
+    })
+    it('should add a character with initiative somewhere in the middle', () => {
+      const newCharacter = {
+        name: 'newPerson',
+        initiative: 15
+      }
+      expect(initiative(inCombatInitialState, addInitiative(newCharacter))).toEqual({
+        inCombat: true,
+        initiativeList: [{
+          name: 'Karis',
+          initiative: 16,
+          turn: true
+        }, {
+          name: 'newPerson',
+          initiative: 15,
+          turn: false
+        }, {
+          name: 'Riku',
+          initiative: 14,
+          turn: false
+        }]
+      })
     })
   })
 })


### PR DESCRIPTION
When in combat, we don't want to automatically change whose turn it is, even when adding people to the initiative order who might have a higher initiative value.